### PR TITLE
Bumped chart version to match HBTD 1.15.0. No other chart changes.

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2021-12-21
+
+### Changed
+
+- HBTD now uses new hms-msgbus which replaces Sarama kafka with Confluent.
+
 ## [2.0.0] - 2021-11-19
 
 ### Changed

--- a/charts/v2.0/cray-hms-hbtd/Chart.yaml
+++ b/charts/v2.0/cray-hms-hbtd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hbtd"
-version: 2.0.0
+version: 2.0.1
 description: "Kubernetes resources for cray-hms-hbtd"
 home: "https://github.com/Cray-HPE/hms-hbtd-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.14.0"
+appVersion: "1.15.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-hms-hbtd/values.yaml
+++ b/charts/v2.0/cray-hms-hbtd/values.yaml
@@ -8,7 +8,7 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.14.0
+  appVersion: 1.15.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-hbtd

--- a/cray-hms-hbtd.compatibility.yaml
+++ b/cray-hms-hbtd.compatibility.yaml
@@ -10,6 +10,7 @@ chartVersionToCSMVersion:
 chartVersionToApplicationVersion:
   # Chart version: Application version
   "2.0.0": "1.14.0"
+  "2.0.1": "1.15.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
Bumped chart version to match HBTD 1.15.0. No other chart changes.

Resolves, in part, CASMHMS-3089.
