### PR TITLE
Change HSM v1 API references to v2

### DIFF
--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.3] - 2022-07-01
+
+### Changed
+
+- Change HSM v1 API references to v2
+
 ## [2.1.2] - 2022-06-22
 
 ### Changed

--- a/charts/v2.1/cray-hms-hbtd/Chart.yaml
+++ b/charts/v2.1/cray-hms-hbtd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hbtd"
-version: 2.1.2
+version: 2.1.3
 description: "Kubernetes resources for cray-hms-hbtd"
 home: "https://github.com/Cray-HPE/hms-hbtd-charts"
 sources:

--- a/charts/v2.1/cray-hms-hbtd/values.yaml
+++ b/charts/v2.1/cray-hms-hbtd/values.yaml
@@ -66,7 +66,7 @@ cray-service:
           containerPort: 28500
       env:
         - name: SM_URL
-          value: "http://cray-smd/hsm/v1"
+          value: "http://cray-smd/hsm/v2"
         - name: WARNTIME
           value: "35"
         - name: ERRTIME

--- a/cray-hms-hbtd.compatibility.yaml
+++ b/cray-hms-hbtd.compatibility.yaml
@@ -16,6 +16,7 @@ chartVersionToApplicationVersion:
   "2.1.0": "1.16.0"
   "2.1.1": "1.16.0"
   "2.1.2": "1.18.0"
+  "2.1.3": "1.18.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Change HSM v1 API references to v2 in HBTD

## Issues and Related PRs

* Resolves [CASMHMS-5546](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5546)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable