### PR TITLE
CASMTRIAGE-5393 Add disasterRecovery section

### DIFF
--- a/changelog/v3.0.md
+++ b/changelog/v3.0.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [3.0.1] - 2023-05-18
+
+### Added
+
+- Added disasterRecovery section to chart
+
 ## [3.0.0] - 2023-03-20
 
 ### Changed

--- a/charts/v3.0/cray-hms-hbtd/Chart.yaml
+++ b/charts/v3.0/cray-hms-hbtd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hbtd"
-version: 3.0.0
+version: 3.0.1
 description: "Kubernetes resources for cray-hms-hbtd"
 home: "https://github.com/Cray-HPE/hms-hbtd-charts"
 sources:

--- a/charts/v3.0/cray-hms-hbtd/values.yaml
+++ b/charts/v3.0/cray-hms-hbtd/values.yaml
@@ -29,6 +29,12 @@ cray-etcd-base:
     nameOverride: "cray-hbtd-bitnami-etcd"
     persistence:
       size: 8Gi
+    disasterRecovery:
+      cronjob:
+        snapshotsDir: "/snapshots/cray-hbtd-bitnami-etcd"
+        schedule: "0 */1 * * *"
+        historyLimit: 1
+        snapshotHistoryLimit: 24
     extraEnvVars:
       - name: ETCD_HEARTBEAT_INTERVAL
         value: "4200"

--- a/cray-hms-hbtd.compatibility.yaml
+++ b/cray-hms-hbtd.compatibility.yaml
@@ -20,6 +20,7 @@ chartVersionToApplicationVersion:
   "2.1.3": "1.18.0"
   "2.1.4": "1.19.0"
   "3.0.0": "1.19.1"
+  "3.0.1": "1.19.1"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Add required disasterRecovery chart section to allow for ETCD backups.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5393](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5393)

## Testing

Tested on:

  * `drax`

Test description:

Copied chart to drax and initiated a helm upgrade. Verified deployed chart contained the expected changes.

## Risks and Mitigations

No known risks.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable