### PR TITLE
CASMHMS-6414: Updated image and module dependencies for security updates

### DIFF
--- a/changelog/v3.2.md
+++ b/changelog/v3.2.md
@@ -10,10 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - Updated image and module dependencies for security updates
-- Various code changes to accomodate module updates
 - Updated to Go v1.24
 - Added image-pprof Makefile support
-- Resolved build warnings in Dockerfiles and docker compose files
 - Internal tracking ticket: CASMHMS-6414
 
 ## [3.2.0] - 2025-02-22

--- a/changelog/v3.2.md
+++ b/changelog/v3.2.md
@@ -5,6 +5,17 @@ All notable changes to this project for v3.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1] - 2025-03-20
+
+### Security
+
+- Updated image and module dependencies for security updates
+- Various code changes to accomodate module updates
+- Updated to Go v1.24
+- Added image-pprof Makefile support
+- Resolved build warnings in Dockerfiles and docker compose files
+- Internal tracking ticket: CASMHMS-6414
+
 ## [3.2.0] - 2025-02-22
 
 ### Changed

--- a/changelog/v3.2.md
+++ b/changelog/v3.2.md
@@ -5,7 +5,7 @@ All notable changes to this project for v3.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.2.1] - 2025-03-20
+## [3.2.1] - 2025-03-25
 
 ### Security
 

--- a/charts/v3.2/cray-hms-hbtd/Chart.yaml
+++ b/charts/v3.2/cray-hms-hbtd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hbtd"
-version: 3.2.0
+version: 3.2.1
 description: "Kubernetes resources for cray-hms-hbtd"
 home: "https://github.com/Cray-HPE/hms-hbtd-charts"
 sources:
@@ -15,9 +15,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.22.0"  # update pprof image version below as well
+appVersion: "1.23.0"  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-hbtd-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-hbtd-pprof:1.22.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-hbtd-pprof:1.23.0
   artifacthub.io/license: "MIT"

--- a/charts/v3.2/cray-hms-hbtd/values.yaml
+++ b/charts/v3.2/cray-hms-hbtd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.22.0
-  testVersion: 1.22.0
+  appVersion: 1.23.0
+  testVersion: 1.23.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-hbtd

--- a/cray-hms-hbtd.compatibility.yaml
+++ b/cray-hms-hbtd.compatibility.yaml
@@ -31,6 +31,7 @@ chartVersionToApplicationVersion:
   "3.1.2": "1.21.0"
   "3.1.3": "1.22.0"
   "3.2.0": "1.22.0"
+  "3.2.1": "1.23.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

#### App Changes

Updated image and module dependencies for security updates.

Updated version of Go to v1.24.

Added image-pprof Makefile support as the above module updates fixed the back-end ARM build issue associated with not being able to enable it previously.

#### Chart Changes

Adopted app version 1.23.0 for CSM 1.7.0 (helm chart 3.2.1)

### Issues and Related PRs

* Resolves [CASMHMS-6414](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6414)

### Testing

Ran smoke and integration tests on mug.

Tested on:

* `mug`

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Y
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y 
Was a Downgrade tested?                Y/N   If not, Why? Y 

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable