### PR TITLE
CASMHMS-6512: Bump cray-etcd-base and cray-service to latest versions

### DIFF
--- a/changelog/v3.2.md
+++ b/changelog/v3.2.md
@@ -5,12 +5,13 @@ All notable changes to this project for v3.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.2.2] - 2025-05-13
+## [3.2.2] - 2025-05-14
 
 ### Updated
 
 - Updated cray-etcd-base and cray-service dependencies to the latest versions
 - Decreased ETCD_QUOTA_BACKEND_BYTES from 10 GB to 2 GB
+- Internal tracking ticket: CASMHMS-6512
 
 ## [3.2.1] - 2025-03-25
 

--- a/changelog/v3.2.md
+++ b/changelog/v3.2.md
@@ -5,6 +5,13 @@ All notable changes to this project for v3.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1] - 2025-05-13
+
+### Updated
+
+- Updated cray-etcd-base and cray-service dependencies to the latest versions
+- Decreased ETCD_QUOTA_BACKEND_BYTES from 10 GB to 2 GB
+
 ## [3.2.1] - 2025-03-25
 
 ### Security

--- a/changelog/v3.2.md
+++ b/changelog/v3.2.md
@@ -5,7 +5,7 @@ All notable changes to this project for v3.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.2.1] - 2025-05-13
+## [3.2.2] - 2025-05-13
 
 ### Updated
 

--- a/charts/v3.2/cray-hms-hbtd/Chart.yaml
+++ b/charts/v3.2/cray-hms-hbtd/Chart.yaml
@@ -1,16 +1,16 @@
 apiVersion: v2
 name: "cray-hms-hbtd"
-version: 3.2.1
+version: 3.2.2
 description: "Kubernetes resources for cray-hms-hbtd"
 home: "https://github.com/Cray-HPE/hms-hbtd-charts"
 sources:
   - "https://github.com/Cray-HPE/hms-hmi-service"
 dependencies:
   - name: cray-service
-    version: "~11.0"
+    version: "~12.0"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
   - name: cray-etcd-base
-    version: "~1.2"
+    version: "~1.3"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 maintainers:
   - name: Hardware Management

--- a/charts/v3.2/cray-hms-hbtd/values.yaml
+++ b/charts/v3.2/cray-hms-hbtd/values.yaml
@@ -43,7 +43,7 @@ cray-etcd-base:
       - name: ETCD_MAX_SNAPSHOTS
         value: "1"
       - name: ETCD_QUOTA_BACKEND_BYTES
-        value: "10737418240"
+        value: "2147483648"
       - name: ETCD_SNAPSHOT_COUNT
         value: "5000000"
       - name: ETCD_SNAPSHOT_HISTORY_LIMIT

--- a/cray-hms-hbtd.compatibility.yaml
+++ b/cray-hms-hbtd.compatibility.yaml
@@ -32,6 +32,7 @@ chartVersionToApplicationVersion:
   "3.1.3": "1.22.0"
   "3.2.0": "1.22.0"
   "3.2.1": "1.23.0"
+  "3.2.2": "1.23.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated cray-etcd-base and cray-service dependencies to the latest versions

Decreased ETCD_QUOTA_BACKEND_BYTES from 10 GB to 2 GB

New helm chart version is 3.2.2 (no app version change)

### Issues and Related PRs

* Resolves [CASMHMS-6512](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6512)

### Testing

Tested on:

* `beau` (vshasta)

Test description:

- Helm upgrade of the new chart
- Ran HMS CT tests
- Ran etcd health checks to ensure things were healthy from the start:
  - `/opt/cray/platform-utils/ncnHealthChecks.sh -s etcd_health_status`
  - `/opt/cray/platform-utils/ncnHealthChecks.sh -s etcd_database_health`
- Rebuilt the etcd cluster with:
   - `/opt/cray/platform-utils/etcd/etcd_restore_rebuild.sh -s cray-hbtd`
 - Reran etcd health checks to ensure things were still healthy after the rebuild:
   - `/opt/cray/platform-utils/ncnHealthChecks.sh -s etcd_health_status`
   - `/opt/cray/platform-utils/ncnHealthChecks.sh -s etcd_database_health`
- Re-ran HMS CT tests to verify all tests still pass after the rebuild
- Helm rollback to the prior version of the service

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable