### PR TITLE
CASMHMS-6393: Explicitly closed all request and response bodies using hms-base APIs

### DIFF
--- a/changelog/v3.2.md
+++ b/changelog/v3.2.md
@@ -5,7 +5,7 @@ All notable changes to this project for v3.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.2.3] - 2025-06-03
+## [3.2.3] - 2025-06-04
 
 ### Updated
 

--- a/changelog/v3.2.md
+++ b/changelog/v3.2.md
@@ -5,6 +5,15 @@ All notable changes to this project for v3.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.3] - 2025-06-03
+
+### Updated
+
+- Updated image and module dependencies
+- Explicitly closed all request and response bodies using hms-base functions
+- Fixed bug with jq use in runSnyk.sh
+- Internal tracking ticket: CASMHMS-6400
+
 ## [3.2.2] - 2025-05-14
 
 ### Updated

--- a/changelog/v3.2.md
+++ b/changelog/v3.2.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 
 - Updated image and module dependencies
+        - hms-base v2.3.0
+        - hms-hmetcd v1.13.0
+        - hms-msgbus v1.13.1
 - Explicitly closed all request and response bodies using hms-base functions
 - Fixed bug with jq use in runSnyk.sh
 - Internal tracking ticket: CASMHMS-6400

--- a/charts/v3.2/cray-hms-hbtd/Chart.yaml
+++ b/charts/v3.2/cray-hms-hbtd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hbtd"
-version: 3.2.2
+version: 3.2.3
 description: "Kubernetes resources for cray-hms-hbtd"
 home: "https://github.com/Cray-HPE/hms-hbtd-charts"
 sources:
@@ -15,9 +15,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.23.0"  # update pprof image version below as well
+appVersion: "1.24.0"  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-hbtd-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-hbtd-pprof:1.23.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-hbtd-pprof:1.24.0
   artifacthub.io/license: "MIT"

--- a/charts/v3.2/cray-hms-hbtd/values.yaml
+++ b/charts/v3.2/cray-hms-hbtd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.23.0
-  testVersion: 1.23.0
+  appVersion: 1.24.0
+  testVersion: 1.24.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-hbtd

--- a/cray-hms-hbtd.compatibility.yaml
+++ b/cray-hms-hbtd.compatibility.yaml
@@ -33,6 +33,7 @@ chartVersionToApplicationVersion:
   "3.2.0": "1.22.0"
   "3.2.1": "1.23.0"
   "3.2.2": "1.23.0"
+  "3.2.3": "1.24.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated all module and image dependencies to latest versions.  The primary reason for this was to pick up some resource leak fixes to the HMS module dependencies.

Used hms-base APIs for explicitly draining and closing http request and response bodies.

Fixed a bug with jq use when running runSnyk.sh

Adopted app version 1.24.0 for CSM 1.7.0 (helm chart 3.2.3).

### Issues and Related PRs

* Resolves [CASMHMS-6393](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6393)

### Testing

Tested on:

* `mug`

Test description:

Upgraded to dev version of service.  Watched log files to ensure nothing obvious was wrong.  Verified all CT tests still pass.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable