### PR TITLE
CASMHMS-6599: Update image dependencies

### DIFF
--- a/.github/workflows/k8s_api_checker.yaml
+++ b/.github/workflows/k8s_api_checker.yaml
@@ -2,5 +2,5 @@ name: Kubernetes API Checker
 on: [push, pull_request, workflow_dispatch]
 jobs:
   k8s_api_checker:
-    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/k8s_api_checker.yaml@v2
+    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/k8s_api_checker.yaml@v4
     secrets: inherit

--- a/changelog/v3.2.md
+++ b/changelog/v3.2.md
@@ -5,6 +5,14 @@ All notable changes to this project for v3.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.4] - 2025-09-23
+
+### Security
+
+- Updated Alpine base image to pick up security fixes
+- Updated CT test image version dependencies
+- Internal tracking ticket: CASMHMS-6599
+
 ## [3.2.3] - 2025-06-04
 
 ### Updated

--- a/changelog/v3.2.md
+++ b/changelog/v3.2.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- Updated Alpine base image to pick up security fixes
+- Updated Alpine base image to pick up security fixes 
 - Updated CT test image version dependencies
 - Internal tracking ticket: CASMHMS-6599
 

--- a/changelog/v3.2.md
+++ b/changelog/v3.2.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated Alpine base image to pick up security fixes
 - Updated CT test image version dependencies
+- Updated k8s_api_checker.yaml from v2 to v4
 - Internal tracking ticket: CASMHMS-6599
 
 ## [3.2.3] - 2025-06-04

--- a/changelog/v3.2.md
+++ b/changelog/v3.2.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- Updated Alpine base image to pick up security fixes 
+- Updated Alpine base image to pick up security fixes
 - Updated CT test image version dependencies
 - Internal tracking ticket: CASMHMS-6599
 

--- a/charts/v3.2/cray-hms-hbtd/Chart.yaml
+++ b/charts/v3.2/cray-hms-hbtd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hbtd"
-version: 3.2.3
+version: 3.2.4
 description: "Kubernetes resources for cray-hms-hbtd"
 home: "https://github.com/Cray-HPE/hms-hbtd-charts"
 sources:
@@ -15,9 +15,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.24.0"  # update pprof image version below as well
+appVersion: "1.25.0"  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-hbtd-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-hbtd-pprof:1.24.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-hbtd-pprof:1.25.0
   artifacthub.io/license: "MIT"

--- a/charts/v3.2/cray-hms-hbtd/values.yaml
+++ b/charts/v3.2/cray-hms-hbtd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.24.0
-  testVersion: 1.24.0
+  appVersion: 1.25.0
+  testVersion: 1.25.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-hbtd

--- a/cray-hms-hbtd.compatibility.yaml
+++ b/cray-hms-hbtd.compatibility.yaml
@@ -34,6 +34,7 @@ chartVersionToApplicationVersion:
   "3.2.1": "1.23.0"
   "3.2.2": "1.23.0"
   "3.2.3": "1.24.0"
+  "3.2.4": "1.25.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated Alpine base image from 3.21 to 3.22 to pick up security fixes.

Updated CT test image version dependencies so that the test infractructure always references the latest versions of HMS services.

Also updated chart build usage of k8s_api_checker.yaml workflow from v2 to v4 because we were having build issues.

Adopted app version 1.25.0 for CSM 1.7.1 (helm chart 3.2.4)

### Issues and Related PRs

* Resolves [CASMHMS-6599](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6599)

### Testing

Tested via pipeline execution of CT tests and on system mug.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable